### PR TITLE
Add right wall 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # What's this?
 
-I'm playing around with the matter.js engine. I painstakingly put together a person's body on the canvas. Seriously, it took longer than I thought! The documentation for matter.js is a little opaque! 
+I'm playing around with the matter.js engine. I painstakingly put together a person's body on the canvas. Seriously, it took longer than I thought! The documentation for matter.js is a little opaque.
 
 You can drag him around and throw things at him. 
+
+# The meat
+
+This was like a little art project. Decided that I wanted to make shapes for each body part and used [constraints](https://brm.io/matter-js/docs/classes/Constraint.html) (which are like springs that you can adjust to be more rigid or more elastic with damping or not) to connect the body parts together. 
+
+As far as I can tell, matter.js seems to be able to hook into a canvas html object. If you don't specify one, it makes one on its own. If you specify one, you can tweak the size by providing configuration information in the form of an options object to the Renderer. All physics objects made need to get added to the World, then you can run the engine to initialize it all.
 
 ![dude](./matter_exp.png)

--- a/index.html
+++ b/index.html
@@ -60,7 +60,8 @@ const box4 = Bodies.rectangle(900, 250, 100, 20);
 const positioner = Bodies.rectangle(900, 500, 80, 100);
 
 const ground = Bodies.rectangle(400, 710, 3000, 60, { isStatic: true });
-const wall = Bodies.rectangle(10, 300, 60, 1000, { isStatic: true});
+const left_wall = Bodies.rectangle(10, 300, 60, 1800, { isStatic: true});
+const right_wall = Bodies.rectangle(1600, 300, 60, 1800, { isStatic: true});
 
 // add mouse control
 var mouse = Mouse.create(render.canvas),
@@ -79,7 +80,7 @@ rightUpperArm, rightForearm, leftThigh, rightThigh, leftCalf, rightCalf];
 
 let objects = [box1, box2, box3, box4, positioner];
 
-World.add(engine.world, [...bodyParts, ...objects, ground, wall]);
+World.add(engine.world, [...bodyParts, ...objects, ground, left_wall, right_wall]);
 World.add(engine.world, mouseConstraint);
 
 // Was gonna do more with playing around with stiffness and length but it's fine for now


### PR DESCRIPTION
I was showing this to a coworker and he flicked the figure off to the right, where the figure proceeded to disappear forever. While that's fun, there's too many directions you can do that from so I followed my heart and made a right wall. You can still flick the figure off towards the sky. 

This represents the walls that arise to curtail personal freedoms in order to better preserve and control society. 